### PR TITLE
Fix problem with UI getting cut of when Global Font Scale is > 12.0pt

### DIFF
--- a/StartupCommandsPlugin/UI/ConfigWindow.cs
+++ b/StartupCommandsPlugin/UI/ConfigWindow.cs
@@ -7,36 +7,7 @@ namespace FfxivStartupCommands
 
     public class ConfigWindow : UIWindow
     {
-        private const float MinimumWindowWidth = 450;
-        private const float MinimumWindowHeight = 170;
-        
         #region Properties
-        public override Vector2 WindowSize
-        {
-            get
-            {
-                int customCommandCount = Plugin.Configuration.CustomCommands != null
-                                             ? Plugin.Configuration.CustomCommands.Count
-                                             : 0;
-                
-                float flexHeight = 27 * customCommandCount;
-
-                float newWidth = MinimumWindowWidth;
-                float newHeight = MinimumWindowHeight + flexHeight;
-
-                return new Vector2(newWidth, newHeight);
-            }
-        }
-
-
-
-        protected override ImGuiWindowFlags WindowFlags { get; } =
-            ImGuiWindowFlags.NoScrollbar 
-            | ImGuiWindowFlags.NoScrollWithMouse
-            | ImGuiWindowFlags.NoCollapse
-            | ImGuiWindowFlags.NoResize;
-
-
         protected override string WindowTitle { get; } = "Startup Commands Configuration";
         #endregion
 
@@ -47,18 +18,9 @@ namespace FfxivStartupCommands
             
             DrawChatChannelSelection();
 
-            ImGui.Spacing();
-            ImGui.Spacing();
-
             DrawCustomCommands();
 
-            ImGui.NewLine();
-            ImGui.NewLine();
-
             DrawExecuteButton();
-            
-            ImGui.SameLine(this.WindowSize.X - 146);
-            
         }
 
 
@@ -102,7 +64,6 @@ namespace FfxivStartupCommands
                 string currentChatCommand = customCommand.Command;
                 ImGui.Bullet();
                 ImGui.SameLine();
-                ImGui.PushItemWidth(this.WindowSize.X - 105);
 
                 updated = ImGui.InputText($"###inputText_Command_{index}", ref currentChatCommand, 512);
 

--- a/StartupCommandsPlugin/UI/UIWindow.cs
+++ b/StartupCommandsPlugin/UI/UIWindow.cs
@@ -16,10 +16,6 @@ namespace FfxivStartupCommands
             set { this.isVisible = value; }
         }
 
-        public virtual Vector2 WindowSize { get; set; } = new Vector2(0, 0);
-
-        protected abstract ImGuiWindowFlags WindowFlags { get; }
-
         protected abstract string WindowTitle { get; }
         #endregion
 
@@ -32,11 +28,10 @@ namespace FfxivStartupCommands
             if (!this.IsVisible)
                 return;
 
-            ImGui.SetNextWindowSize(this.WindowSize, ImGuiCond.Always);
+            ImGui.SetNextWindowSize(new Vector2(520, 480), ImGuiCond.FirstUseEver);
             if (ImGui.Begin(
                 this.WindowTitle,
-                ref this.isVisible, 
-                this.WindowFlags))
+                ref this.isVisible))
             {
                 OnDraw();
             }


### PR DESCRIPTION
This fixes issue https://github.com/saltycog/ffxiv-startup-commands/issues/2, but it kind of undoes a fair amount of well-intentioned and cool automatic window resizing features in order to stay compatible with larger fonts.

You can take it or leave it. I won't be offended. I'm content to just run on my own forked copy if you want to keep it as is.

And thank you for your work on this project. I used it as an excuse to learn the ins and outs of working with the UI for ImGui.